### PR TITLE
Typo fix in packages/svelte/build.js

### DIFF
--- a/packages/svelte/build.js
+++ b/packages/svelte/build.js
@@ -168,7 +168,7 @@ function cleanup() {
 			.trim()
 			.replace(/\r/g, '')
 			.split('\n\n');
-		if (svelteParts.lenght < 2) {
+		if (svelteParts.length < 2) {
 			throw new Error(
 				'Error parsing svelte.d.ts. Imports and content should be separated by 2 new lines'
 			);


### PR DESCRIPTION
Just a quick typo fix found on `packages/svelte/build.js` @ `171`: 

https://github.com/iconify/iconify/blob/master/packages/svelte/build.js#L171

And with the two letters in their proper places... voila:

```js
if (svelteParts.length < 2) {
```

That is all for now, thanks 😁