### PR TITLE
Make styles safe

### DIFF
--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -27,6 +27,7 @@
 		"@microsoft/api-extractor": "^7.19.4",
 		"@rollup/plugin-node-resolve": "^13.1.3",
 		"@rollup/plugin-typescript": "^8.3.0",
+		"ember-source": "~4.1.0",
 		"rollup": "^2.66.0",
 		"typescript": "^4.5.5"
 	},

--- a/packages/ember/rollup.config.js
+++ b/packages/ember/rollup.config.js
@@ -11,7 +11,7 @@ const config = [
 				format: 'esm',
 			},
 		],
-		external: ['@glimmer/component', '@glimmer/tracking'],
+		external: ['@ember/template', '@glimmer/component', '@glimmer/tracking'],
 		plugins: [
 			resolve({
 				browser: true,

--- a/packages/ember/src/render.ts
+++ b/packages/ember/src/render.ts
@@ -1,3 +1,4 @@
+import { htmlSafe } from '@ember/template';
 import type { IconifyIcon } from '@iconify/types';
 import type { FullIconCustomisations } from '@iconify/utils/lib/customisations';
 import {
@@ -124,7 +125,7 @@ export const render = (
 
 	return {
 		...item.attributes,
-		style: style === '' ? void 0 : style,
+		style: style === '' ? void 0 : htmlSafe(style),
 		className,
 		body,
 	};


### PR DESCRIPTION
In `Ember.js` styles need to go through [htmlSafe](https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe) otherwise it will log a warning.

Reference https://deprecations.emberjs.com/v1.x/#toc_warning-when-binding-style-attributes