### PR TITLE
fix(react): add react as peer dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,6 +60,6 @@
 		"typescript": "^4.6.2"
 	},
 	"peerDependencies": {
-		"react": "^16.8 || ^17.0 || ^18.0"
+		"react": ">=16"
 	}
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,5 +58,8 @@
 		"rimraf": "^3.0.2",
 		"rollup": "^2.70.1",
 		"typescript": "^4.6.2"
+	},
+	"peerDependencies": {
+		"react": "^16.8 || ^17.0 || ^18.0"
 	}
 }


### PR DESCRIPTION
Yarn 3 in PnP mode currently breaks when trying to use `@iconify/react`, because it doesn't declare React as a peer dependency. In issue #59 ([comment](https://github.com/iconify/iconify/issues/59#issuecomment-774931449)), the existing peer dependency was removed as a "fix", instead of simply expanding the range to include both versions. This PR re-adds the peer dependency requirement for React, with an expanded range to cover React 16, 17, and 18.