### PR TITLE
fix: remove attributes instead of setting them to null

### DIFF
--- a/iconify-icon/icon/src/component.ts
+++ b/iconify-icon/icon/src/component.ts
@@ -385,7 +385,11 @@ export function defineIconifyIcon(
 					return this.getAttribute(attr);
 				},
 				set: function (value) {
-					this.setAttribute(attr, value);
+					if(value !== null){
+						this.setAttribute(attr, value);
+					}else{
+						this.removeAttribute(attr);
+					}
 				},
 			});
 		}


### PR DESCRIPTION
This pull request relates to issue #201, which was has been closed. I ran into the same issue I had with the 'inline' attribute in that issue with other attributes like 'height', 'width', etc. I double checked the Iconify docs to ensure none of these affected attributes have a valid use case for a null value.