### PR TITLE
[vue3]: fix typo props component `Icon`

### DIFF
--- a/components/vue/src/iconify.ts
+++ b/components/vue/src/iconify.ts
@@ -236,7 +236,7 @@ interface IconComponentData {
 	classes?: string[];
 }
 
-export const Icon = defineComponent({
+export const Icon = defineComponent<IconProps>({
 	// Do not inherit other attributes: it is handled by render()
 	inheritAttrs: false,
 


### PR DESCRIPTION
fix https://github.com/iconify/iconify/issues/95
fix same error on vue 3 sfc volar