### PR TITLE
fix: correct svelte component's TS type

### DIFF
--- a/components/svelte/src/svelte.d.ts
+++ b/components/svelte/src/svelte.d.ts
@@ -1,6 +1,6 @@
-import { SvelteComponent } from 'svelte';
+import { SvelteComponentTyped } from 'svelte';
 
 /**
  * Svelte component
  */
-export default class Icon extends SvelteComponent {}
+export default class Icon extends SvelteComponentTyped<IconProps> {}


### PR DESCRIPTION
Below is quoted from [svelte/src/runtime/internal/dev.ts](https://github.com/sveltejs/svelte/blob/d42ca041dd7817ae772a9da2d0aea56f557088d1/src/runtime/internal/dev.ts#L238-L268)

> You have component library on npm called `component-library`, from which
> you export a component called `MyComponent`. For Svelte+TypeScript users,
> you want to provide typings. Therefore you create a `index.d.ts`:
> ```ts
> import { SvelteComponentTyped } from "svelte";
> export class MyComponent extends SvelteComponentTyped<{foo: string}> {}
> ```
> Typing this makes it possible for IDEs like VS Code with the Svelte extension
> to provide intellisense and to use the component like this in a Svelte file

This way we can correctly expose component props types, and get nice code completion hint in IDE. Previously this info was exposed.

![image](https://user-images.githubusercontent.com/8945315/230696161-a771c5b6-1106-4940-b482-646b38e43ed2.png)