### PR TITLE
fix(next): types in package exports

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,370 +27,370 @@
 	"types": "lib/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"require": "./lib/index.cjs",
-			"import": "./lib/index.mjs",
-			"types": "./lib/index.d.ts"
+			"import": "./lib/index.mjs"
 		},
 		"./*": "./*",
 		"./lib/colors": {
+			"types": "./lib/colors/index.d.ts",
 			"require": "./lib/colors/index.cjs",
-			"import": "./lib/colors/index.mjs",
-			"types": "./lib/colors/index.d.ts"
+			"import": "./lib/colors/index.mjs"
 		},
 		"./lib/colors/index": {
+			"types": "./lib/colors/index.d.ts",
 			"require": "./lib/colors/index.cjs",
-			"import": "./lib/colors/index.mjs",
-			"types": "./lib/colors/index.d.ts"
+			"import": "./lib/colors/index.mjs"
 		},
 		"./lib/colors/keywords": {
+			"types": "./lib/colors/keywords.d.ts",
 			"require": "./lib/colors/keywords.cjs",
-			"import": "./lib/colors/keywords.mjs",
-			"types": "./lib/colors/keywords.d.ts"
+			"import": "./lib/colors/keywords.mjs"
 		},
 		"./lib/colors/types": {
+			"types": "./lib/colors/types.d.ts",
 			"require": "./lib/colors/types.cjs",
-			"import": "./lib/colors/types.mjs",
-			"types": "./lib/colors/types.d.ts"
+			"import": "./lib/colors/types.mjs"
 		},
 		"./lib/css/common": {
+			"types": "./lib/css/common.d.ts",
 			"require": "./lib/css/common.cjs",
-			"import": "./lib/css/common.mjs",
-			"types": "./lib/css/common.d.ts"
+			"import": "./lib/css/common.mjs"
 		},
 		"./lib/css/format": {
+			"types": "./lib/css/format.d.ts",
 			"require": "./lib/css/format.cjs",
-			"import": "./lib/css/format.mjs",
-			"types": "./lib/css/format.d.ts"
+			"import": "./lib/css/format.mjs"
 		},
 		"./lib/css/icon": {
+			"types": "./lib/css/icon.d.ts",
 			"require": "./lib/css/icon.cjs",
-			"import": "./lib/css/icon.mjs",
-			"types": "./lib/css/icon.d.ts"
+			"import": "./lib/css/icon.mjs"
 		},
 		"./lib/css/icons": {
+			"types": "./lib/css/icons.d.ts",
 			"require": "./lib/css/icons.cjs",
-			"import": "./lib/css/icons.mjs",
-			"types": "./lib/css/icons.d.ts"
+			"import": "./lib/css/icons.mjs"
 		},
 		"./lib/css/types": {
+			"types": "./lib/css/types.d.ts",
 			"require": "./lib/css/types.cjs",
-			"import": "./lib/css/types.mjs",
-			"types": "./lib/css/types.d.ts"
+			"import": "./lib/css/types.mjs"
 		},
 		"./lib/customisations/bool": {
+			"types": "./lib/customisations/bool.d.ts",
 			"require": "./lib/customisations/bool.cjs",
-			"import": "./lib/customisations/bool.mjs",
-			"types": "./lib/customisations/bool.d.ts"
+			"import": "./lib/customisations/bool.mjs"
 		},
 		"./lib/customisations/defaults": {
+			"types": "./lib/customisations/defaults.d.ts",
 			"require": "./lib/customisations/defaults.cjs",
-			"import": "./lib/customisations/defaults.mjs",
-			"types": "./lib/customisations/defaults.d.ts"
+			"import": "./lib/customisations/defaults.mjs"
 		},
 		"./lib/customisations/flip": {
+			"types": "./lib/customisations/flip.d.ts",
 			"require": "./lib/customisations/flip.cjs",
-			"import": "./lib/customisations/flip.mjs",
-			"types": "./lib/customisations/flip.d.ts"
+			"import": "./lib/customisations/flip.mjs"
 		},
 		"./lib/customisations/merge": {
+			"types": "./lib/customisations/merge.d.ts",
 			"require": "./lib/customisations/merge.cjs",
-			"import": "./lib/customisations/merge.mjs",
-			"types": "./lib/customisations/merge.d.ts"
+			"import": "./lib/customisations/merge.mjs"
 		},
 		"./lib/customisations/rotate": {
+			"types": "./lib/customisations/rotate.d.ts",
 			"require": "./lib/customisations/rotate.cjs",
-			"import": "./lib/customisations/rotate.mjs",
-			"types": "./lib/customisations/rotate.d.ts"
+			"import": "./lib/customisations/rotate.mjs"
 		},
 		"./lib/emoji/regex/base": {
+			"types": "./lib/emoji/regex/base.d.ts",
 			"require": "./lib/emoji/regex/base.cjs",
-			"import": "./lib/emoji/regex/base.mjs",
-			"types": "./lib/emoji/regex/base.d.ts"
+			"import": "./lib/emoji/regex/base.mjs"
 		},
 		"./lib/emoji/regex/create": {
+			"types": "./lib/emoji/regex/create.d.ts",
 			"require": "./lib/emoji/regex/create.cjs",
-			"import": "./lib/emoji/regex/create.mjs",
-			"types": "./lib/emoji/regex/create.d.ts"
+			"import": "./lib/emoji/regex/create.mjs"
 		},
 		"./lib/emoji/regex/numbers": {
+			"types": "./lib/emoji/regex/numbers.d.ts",
 			"require": "./lib/emoji/regex/numbers.cjs",
-			"import": "./lib/emoji/regex/numbers.mjs",
-			"types": "./lib/emoji/regex/numbers.d.ts"
+			"import": "./lib/emoji/regex/numbers.mjs"
 		},
 		"./lib/emoji/regex/similar": {
+			"types": "./lib/emoji/regex/similar.d.ts",
 			"require": "./lib/emoji/regex/similar.cjs",
-			"import": "./lib/emoji/regex/similar.mjs",
-			"types": "./lib/emoji/regex/similar.d.ts"
+			"import": "./lib/emoji/regex/similar.mjs"
 		},
 		"./lib/emoji/regex/tree": {
+			"types": "./lib/emoji/regex/tree.d.ts",
 			"require": "./lib/emoji/regex/tree.cjs",
-			"import": "./lib/emoji/regex/tree.mjs",
-			"types": "./lib/emoji/regex/tree.d.ts"
+			"import": "./lib/emoji/regex/tree.mjs"
 		},
 		"./lib/emoji/replace/find": {
+			"types": "./lib/emoji/replace/find.d.ts",
 			"require": "./lib/emoji/replace/find.cjs",
-			"import": "./lib/emoji/replace/find.mjs",
-			"types": "./lib/emoji/replace/find.d.ts"
+			"import": "./lib/emoji/replace/find.mjs"
 		},
 		"./lib/emoji/replace/replace": {
+			"types": "./lib/emoji/replace/replace.d.ts",
 			"require": "./lib/emoji/replace/replace.cjs",
-			"import": "./lib/emoji/replace/replace.mjs",
-			"types": "./lib/emoji/replace/replace.d.ts"
+			"import": "./lib/emoji/replace/replace.mjs"
 		},
 		"./lib/emoji/test/components": {
+			"types": "./lib/emoji/test/components.d.ts",
 			"require": "./lib/emoji/test/components.cjs",
-			"import": "./lib/emoji/test/components.mjs",
-			"types": "./lib/emoji/test/components.d.ts"
+			"import": "./lib/emoji/test/components.mjs"
 		},
 		"./lib/emoji/test/missing": {
+			"types": "./lib/emoji/test/missing.d.ts",
 			"require": "./lib/emoji/test/missing.cjs",
-			"import": "./lib/emoji/test/missing.mjs",
-			"types": "./lib/emoji/test/missing.d.ts"
+			"import": "./lib/emoji/test/missing.mjs"
 		},
 		"./lib/emoji/test/name": {
+			"types": "./lib/emoji/test/name.d.ts",
 			"require": "./lib/emoji/test/name.cjs",
-			"import": "./lib/emoji/test/name.mjs",
-			"types": "./lib/emoji/test/name.d.ts"
+			"import": "./lib/emoji/test/name.mjs"
 		},
 		"./lib/emoji/test/parse": {
+			"types": "./lib/emoji/test/parse.d.ts",
 			"require": "./lib/emoji/test/parse.cjs",
-			"import": "./lib/emoji/test/parse.mjs",
-			"types": "./lib/emoji/test/parse.d.ts"
+			"import": "./lib/emoji/test/parse.mjs"
 		},
 		"./lib/emoji/test/tree": {
+			"types": "./lib/emoji/test/tree.d.ts",
 			"require": "./lib/emoji/test/tree.cjs",
-			"import": "./lib/emoji/test/tree.mjs",
-			"types": "./lib/emoji/test/tree.d.ts"
+			"import": "./lib/emoji/test/tree.mjs"
 		},
 		"./lib/emoji/test/similar": {
+			"types": "./lib/emoji/test/similar.d.ts",
 			"require": "./lib/emoji/test/similar.cjs",
-			"import": "./lib/emoji/test/similar.mjs",
-			"types": "./lib/emoji/test/similar.d.ts"
+			"import": "./lib/emoji/test/similar.mjs"
 		},
 		"./lib/emoji/test/variations": {
+			"types": "./lib/emoji/test/variations.d.ts",
 			"require": "./lib/emoji/test/variations.cjs",
-			"import": "./lib/emoji/test/variations.mjs",
-			"types": "./lib/emoji/test/variations.d.ts"
+			"import": "./lib/emoji/test/variations.mjs"
 		},
 		"./lib/emoji/cleanup": {
+			"types": "./lib/emoji/cleanup.d.ts",
 			"require": "./lib/emoji/cleanup.cjs",
-			"import": "./lib/emoji/cleanup.mjs",
-			"types": "./lib/emoji/cleanup.d.ts"
+			"import": "./lib/emoji/cleanup.mjs"
 		},
 		"./lib/emoji/convert": {
+			"types": "./lib/emoji/convert.d.ts",
 			"require": "./lib/emoji/convert.cjs",
-			"import": "./lib/emoji/convert.mjs",
-			"types": "./lib/emoji/convert.d.ts"
+			"import": "./lib/emoji/convert.mjs"
 		},
 		"./lib/emoji/data": {
+			"types": "./lib/emoji/data.d.ts",
 			"require": "./lib/emoji/data.cjs",
-			"import": "./lib/emoji/data.mjs",
-			"types": "./lib/emoji/data.d.ts"
+			"import": "./lib/emoji/data.mjs"
 		},
 		"./lib/emoji/format": {
+			"types": "./lib/emoji/format.d.ts",
 			"require": "./lib/emoji/format.cjs",
-			"import": "./lib/emoji/format.mjs",
-			"types": "./lib/emoji/format.d.ts"
+			"import": "./lib/emoji/format.mjs"
 		},
 		"./lib/emoji/parse": {
+			"types": "./lib/emoji/parse.d.ts",
 			"require": "./lib/emoji/parse.cjs",
-			"import": "./lib/emoji/parse.mjs",
-			"types": "./lib/emoji/parse.d.ts"
+			"import": "./lib/emoji/parse.mjs"
 		},
 		"./lib/icon-set/convert-info": {
+			"types": "./lib/icon-set/convert-info.d.ts",
 			"require": "./lib/icon-set/convert-info.cjs",
-			"import": "./lib/icon-set/convert-info.mjs",
-			"types": "./lib/icon-set/convert-info.d.ts"
+			"import": "./lib/icon-set/convert-info.mjs"
 		},
 		"./lib/icon-set/expand": {
+			"types": "./lib/icon-set/expand.d.ts",
 			"require": "./lib/icon-set/expand.cjs",
-			"import": "./lib/icon-set/expand.mjs",
-			"types": "./lib/icon-set/expand.d.ts"
+			"import": "./lib/icon-set/expand.mjs"
 		},
 		"./lib/icon-set/get-icon": {
+			"types": "./lib/icon-set/get-icon.d.ts",
 			"require": "./lib/icon-set/get-icon.cjs",
-			"import": "./lib/icon-set/get-icon.mjs",
-			"types": "./lib/icon-set/get-icon.d.ts"
+			"import": "./lib/icon-set/get-icon.mjs"
 		},
 		"./lib/icon-set/get-icons": {
+			"types": "./lib/icon-set/get-icons.d.ts",
 			"require": "./lib/icon-set/get-icons.cjs",
-			"import": "./lib/icon-set/get-icons.mjs",
-			"types": "./lib/icon-set/get-icons.d.ts"
+			"import": "./lib/icon-set/get-icons.mjs"
 		},
 		"./lib/icon-set/minify": {
+			"types": "./lib/icon-set/minify.d.ts",
 			"require": "./lib/icon-set/minify.cjs",
-			"import": "./lib/icon-set/minify.mjs",
-			"types": "./lib/icon-set/minify.d.ts"
+			"import": "./lib/icon-set/minify.mjs"
 		},
 		"./lib/icon-set/parse": {
+			"types": "./lib/icon-set/parse.d.ts",
 			"require": "./lib/icon-set/parse.cjs",
-			"import": "./lib/icon-set/parse.mjs",
-			"types": "./lib/icon-set/parse.d.ts"
+			"import": "./lib/icon-set/parse.mjs"
 		},
 		"./lib/icon-set/tree": {
+			"types": "./lib/icon-set/tree.d.ts",
 			"require": "./lib/icon-set/tree.cjs",
-			"import": "./lib/icon-set/tree.mjs",
-			"types": "./lib/icon-set/tree.d.ts"
+			"import": "./lib/icon-set/tree.mjs"
 		},
 		"./lib/icon-set/validate": {
+			"types": "./lib/icon-set/validate.d.ts",
 			"require": "./lib/icon-set/validate.cjs",
-			"import": "./lib/icon-set/validate.mjs",
-			"types": "./lib/icon-set/validate.d.ts"
+			"import": "./lib/icon-set/validate.mjs"
 		},
 		"./lib/icon-set/validate-basic": {
+			"types": "./lib/icon-set/validate-basic.d.ts",
 			"require": "./lib/icon-set/validate-basic.cjs",
-			"import": "./lib/icon-set/validate-basic.mjs",
-			"types": "./lib/icon-set/validate-basic.d.ts"
+			"import": "./lib/icon-set/validate-basic.mjs"
 		},
 		"./lib/icon/defaults": {
+			"types": "./lib/icon/defaults.d.ts",
 			"require": "./lib/icon/defaults.cjs",
-			"import": "./lib/icon/defaults.mjs",
-			"types": "./lib/icon/defaults.d.ts"
+			"import": "./lib/icon/defaults.mjs"
 		},
 		"./lib/icon/merge": {
+			"types": "./lib/icon/merge.d.ts",
 			"require": "./lib/icon/merge.cjs",
-			"import": "./lib/icon/merge.mjs",
-			"types": "./lib/icon/merge.d.ts"
+			"import": "./lib/icon/merge.mjs"
 		},
 		"./lib/icon/name": {
+			"types": "./lib/icon/name.d.ts",
 			"require": "./lib/icon/name.cjs",
-			"import": "./lib/icon/name.mjs",
-			"types": "./lib/icon/name.d.ts"
+			"import": "./lib/icon/name.mjs"
 		},
 		"./lib/icon/transformations": {
+			"types": "./lib/icon/transformations.d.ts",
 			"require": "./lib/icon/transformations.cjs",
-			"import": "./lib/icon/transformations.mjs",
-			"types": "./lib/icon/transformations.d.ts"
+			"import": "./lib/icon/transformations.mjs"
 		},
 		"./lib": {
+			"types": "./lib/index.d.ts",
 			"require": "./lib/index.cjs",
-			"import": "./lib/index.mjs",
-			"types": "./lib/index.d.ts"
+			"import": "./lib/index.mjs"
 		},
 		"./lib/index": {
+			"types": "./lib/index.d.ts",
 			"require": "./lib/index.cjs",
-			"import": "./lib/index.mjs",
-			"types": "./lib/index.d.ts"
+			"import": "./lib/index.mjs"
 		},
 		"./lib/loader/custom": {
+			"types": "./lib/loader/custom.d.ts",
 			"require": "./lib/loader/custom.cjs",
-			"import": "./lib/loader/custom.mjs",
-			"types": "./lib/loader/custom.d.ts"
+			"import": "./lib/loader/custom.mjs"
 		},
 		"./lib/loader/fs": {
+			"types": "./lib/loader/fs.d.ts",
 			"require": "./lib/loader/fs.cjs",
-			"import": "./lib/loader/fs.mjs",
-			"types": "./lib/loader/fs.d.ts"
+			"import": "./lib/loader/fs.mjs"
 		},
 		"./lib/loader/install-pkg": {
+			"types": "./lib/loader/install-pkg.d.ts",
 			"require": "./lib/loader/install-pkg.cjs",
-			"import": "./lib/loader/install-pkg.mjs",
-			"types": "./lib/loader/install-pkg.d.ts"
+			"import": "./lib/loader/install-pkg.mjs"
 		},
 		"./lib/loader/loader": {
+			"types": "./lib/loader/loader.d.ts",
 			"require": "./lib/loader/loader.cjs",
-			"import": "./lib/loader/loader.mjs",
-			"types": "./lib/loader/loader.d.ts"
+			"import": "./lib/loader/loader.mjs"
 		},
 		"./lib/loader/modern": {
+			"types": "./lib/loader/modern.d.ts",
 			"require": "./lib/loader/modern.cjs",
-			"import": "./lib/loader/modern.mjs",
-			"types": "./lib/loader/modern.d.ts"
+			"import": "./lib/loader/modern.mjs"
 		},
 		"./lib/loader/node-loader": {
+			"types": "./lib/loader/node-loader.d.ts",
 			"require": "./lib/loader/node-loader.cjs",
-			"import": "./lib/loader/node-loader.mjs",
-			"types": "./lib/loader/node-loader.d.ts"
+			"import": "./lib/loader/node-loader.mjs"
 		},
 		"./lib/loader/node-loaders": {
+			"types": "./lib/loader/node-loaders.d.ts",
 			"require": "./lib/loader/node-loaders.cjs",
-			"import": "./lib/loader/node-loaders.mjs",
-			"types": "./lib/loader/node-loaders.d.ts"
+			"import": "./lib/loader/node-loaders.mjs"
 		},
 		"./lib/loader/types": {
+			"types": "./lib/loader/types.d.ts",
 			"require": "./lib/loader/types.cjs",
-			"import": "./lib/loader/types.mjs",
-			"types": "./lib/loader/types.d.ts"
+			"import": "./lib/loader/types.mjs"
 		},
 		"./lib/loader/utils": {
+			"types": "./lib/loader/utils.d.ts",
 			"require": "./lib/loader/utils.cjs",
-			"import": "./lib/loader/utils.mjs",
-			"types": "./lib/loader/utils.d.ts"
+			"import": "./lib/loader/utils.mjs"
 		},
 		"./lib/loader/warn": {
+			"types": "./lib/loader/warn.d.ts",
 			"require": "./lib/loader/warn.cjs",
-			"import": "./lib/loader/warn.mjs",
-			"types": "./lib/loader/warn.d.ts"
+			"import": "./lib/loader/warn.mjs"
 		},
 		"./lib/misc/strings": {
+			"types": "./lib/misc/strings.d.ts",
 			"require": "./lib/misc/strings.cjs",
-			"import": "./lib/misc/strings.mjs",
-			"types": "./lib/misc/strings.d.ts"
+			"import": "./lib/misc/strings.mjs"
 		},
 		"./lib/misc/licenses": {
+			"types": "./lib/misc/licenses.d.ts",
 			"require": "./lib/misc/licenses.cjs",
-			"import": "./lib/misc/licenses.mjs",
-			"types": "./lib/misc/licenses.d.ts"
+			"import": "./lib/misc/licenses.mjs"
 		},
 		"./lib/misc/objects": {
+			"types": "./lib/misc/objects.d.ts",
 			"require": "./lib/misc/objects.cjs",
-			"import": "./lib/misc/objects.mjs",
-			"types": "./lib/misc/objects.d.ts"
+			"import": "./lib/misc/objects.mjs"
 		},
 		"./lib/svg/build": {
+			"types": "./lib/svg/build.d.ts",
 			"require": "./lib/svg/build.cjs",
-			"import": "./lib/svg/build.mjs",
-			"types": "./lib/svg/build.d.ts"
+			"import": "./lib/svg/build.mjs"
 		},
 		"./lib/svg/defs": {
+			"types": "./lib/svg/defs.d.ts",
 			"require": "./lib/svg/defs.cjs",
-			"import": "./lib/svg/defs.mjs",
-			"types": "./lib/svg/defs.d.ts"
+			"import": "./lib/svg/defs.mjs"
 		},
 		"./lib/svg/encode-svg-for-css": {
+			"types": "./lib/svg/encode-svg-for-css.d.ts",
 			"require": "./lib/svg/encode-svg-for-css.cjs",
-			"import": "./lib/svg/encode-svg-for-css.mjs",
-			"types": "./lib/svg/encode-svg-for-css.d.ts"
+			"import": "./lib/svg/encode-svg-for-css.mjs"
 		},
 		"./lib/svg/html": {
+			"types": "./lib/svg/html.d.ts",
 			"require": "./lib/svg/html.cjs",
-			"import": "./lib/svg/html.mjs",
-			"types": "./lib/svg/html.d.ts"
+			"import": "./lib/svg/html.mjs"
 		},
 		"./lib/svg/id": {
+			"types": "./lib/svg/id.d.ts",
 			"require": "./lib/svg/id.cjs",
-			"import": "./lib/svg/id.mjs",
-			"types": "./lib/svg/id.d.ts"
+			"import": "./lib/svg/id.mjs"
 		},
 		"./lib/svg/inner-html": {
+			"types": "./lib/svg/inner-html.d.ts",
 			"require": "./lib/svg/inner-html.cjs",
-			"import": "./lib/svg/inner-html.mjs",
-			"types": "./lib/svg/inner-html.d.ts"
+			"import": "./lib/svg/inner-html.mjs"
 		},
 		"./lib/svg/parse": {
+			"types": "./lib/svg/parse.d.ts",
 			"require": "./lib/svg/parse.cjs",
-			"import": "./lib/svg/parse.mjs",
-			"types": "./lib/svg/parse.d.ts"
+			"import": "./lib/svg/parse.mjs"
 		},
 		"./lib/svg/size": {
+			"types": "./lib/svg/size.d.ts",
 			"require": "./lib/svg/size.cjs",
-			"import": "./lib/svg/size.mjs",
-			"types": "./lib/svg/size.d.ts"
+			"import": "./lib/svg/size.mjs"
 		},
 		"./lib/svg/trim": {
+			"types": "./lib/svg/trim.d.ts",
 			"require": "./lib/svg/trim.cjs",
-			"import": "./lib/svg/trim.mjs",
-			"types": "./lib/svg/trim.d.ts"
+			"import": "./lib/svg/trim.mjs"
 		},
 		"./lib/svg/url": {
+			"types": "./lib/svg/url.d.ts",
 			"require": "./lib/svg/url.cjs",
-			"import": "./lib/svg/url.mjs",
-			"types": "./lib/svg/url.d.ts"
+			"import": "./lib/svg/url.mjs"
 		},
 		"./lib/svg/viewbox": {
+			"types": "./lib/svg/viewbox.d.ts",
 			"require": "./lib/svg/viewbox.cjs",
-			"import": "./lib/svg/viewbox.mjs",
-			"types": "./lib/svg/viewbox.d.ts"
+			"import": "./lib/svg/viewbox.mjs"
 		}
 	},
 	"files": [


### PR DESCRIPTION
We should move `types` exports to be the first:

https://arethetypeswrong.github.io/?p=%40iconify%2Futils%402.1.8

https://publint.dev/@iconify/utils@2.1.8

Without this PR (current version):

![imagen](https://github.com/iconify/iconify/assets/6311119/a1ea0d42-f18c-47b0-a167-6e4addaa2537)


With this PR:

![imagen](https://github.com/iconify/iconify/assets/6311119/3412e4be-3a1f-43c6-8311-6f0f053f53f0)
