### PR TITLE
Add scale option to Tailwind plugin

### DIFF
--- a/plugins/tailwind/README.md
+++ b/plugins/tailwind/README.md
@@ -83,6 +83,7 @@ Plugin accepts options as a second parameter:
 
 -   `prefix` is class name prefix. Default value is `icon`. Make sure there is no `-` at the end: it is added in classes, but not in plugin parameter.
 -   `overrideOnly`: set to `true` to generate rules that override only icon data. See below.
+-   `scale`: sets the default icon height/width value. Can be set to 0 which removes the default height/width. Default is 1 (1em).
 -   `files`: list of custom files for icon sets. Key is icon set prefix, value is location of `.json` file with icon set in IconifyJSON format.
 -   `iconSet`: list of custom icon sets. Key is prefix, value is either icon set data in `IconifyJSON` format or a synchronous callback that returns `IconifyJSON` data.
 

--- a/plugins/tailwind/src/dynamic.ts
+++ b/plugins/tailwind/src/dynamic.ts
@@ -8,7 +8,7 @@ import type { DynamicIconifyPluginOptions } from './options';
  */
 export function getDynamicCSSRules(
 	icon: string,
-	options: DynamicIconifyPluginOptions = {}
+	{ scale = 1, ...options }: DynamicIconifyPluginOptions = {}
 ): Record<string, string> {
 	const nameParts = icon.split(/--|\:/);
 	if (nameParts.length !== 2) {
@@ -32,6 +32,14 @@ export function getDynamicCSSRules(
 	});
 	if (generated.css.length !== 1) {
 		throw new Error(`Cannot find "${icon}". Bad icon name?`);
+	}
+
+	if (scale) {
+		generated.common.rules.height = scale + 'em'
+		generated.common.rules.width = scale + 'em'
+	} else {
+		delete generated.common.rules.height
+		delete generated.common.rules.width
 	}
 
 	return {

--- a/plugins/tailwind/src/options.ts
+++ b/plugins/tailwind/src/options.ts
@@ -27,4 +27,7 @@ export interface DynamicIconifyPluginOptions
 
 	// Include icon-specific selectors only
 	overrideOnly?: true;
+
+	// Scale relative to the the default value, (ex. scale: 2 = 2em). Set to 0 to disable default value.
+	scale?: number
 }

--- a/plugins/tailwind/src/options.ts
+++ b/plugins/tailwind/src/options.ts
@@ -13,7 +13,7 @@ export interface CommonIconifyPluginOptions extends IconifyPluginLoaderOptions {
  */
 export interface CleanIconifyPluginOptions
 	extends CommonIconifyPluginOptions,
-		IconCSSIconSetOptions {
+	IconCSSIconSetOptions {
 	//
 }
 
@@ -28,6 +28,6 @@ export interface DynamicIconifyPluginOptions
 	// Include icon-specific selectors only
 	overrideOnly?: true;
 
-	// Scale relative to the the default value, (ex. scale: 2 = 2em). Set to 0 to disable default value.
+	// Sets the default height/width value (ex. scale: 2 = 2em)
 	scale?: number
 }

--- a/plugins/tailwind/tests/dynamic-css-test.ts
+++ b/plugins/tailwind/tests/dynamic-css-test.ts
@@ -29,6 +29,42 @@ describe('Testing dynamic CSS rules', () => {
 		});
 	});
 
+	it('Scale appropriate sets height/width default value', () => {
+		const data = getDynamicCSSRules('mdi-light--home', {
+			scale: 2,
+		});
+		expect(data).toEqual({
+			'display': 'inline-block',
+			'width': '2em',
+			'height': '2em',
+			'background-color': 'currentColor',
+			'-webkit-mask-image': 'var(--svg)',
+			'mask-image': 'var(--svg)',
+			'-webkit-mask-repeat': 'no-repeat',
+			'mask-repeat': 'no-repeat',
+			'-webkit-mask-size': '100% 100%',
+			'mask-size': '100% 100%',
+			'--svg': data['--svg'],
+		});
+	});
+
+	it('Scale removes default value', () => {
+		const data = getDynamicCSSRules('mdi-light--home', {
+			scale: 0,
+		});
+		expect(data).toEqual({
+			'display': 'inline-block',
+			'background-color': 'currentColor',
+			'-webkit-mask-image': 'var(--svg)',
+			'mask-image': 'var(--svg)',
+			'-webkit-mask-repeat': 'no-repeat',
+			'mask-repeat': 'no-repeat',
+			'-webkit-mask-size': '100% 100%',
+			'mask-size': '100% 100%',
+			'--svg': data['--svg'],
+		});
+	});
+
 	it('Missing icon', () => {
 		let threw = false;
 		try {


### PR DESCRIPTION
Fixes https://github.com/iconify/iconify/issues/258

I wasn't sure if it made sense to update core to accept a `scale` option, so I only scoped this change to the Tailwind plugin