### PR TITLE
Fix invalid link to SVG Framework in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ This configuration change is not needed when using Vue with `@vitejs/plugin-vue`
 
 Directory `components` contains Iconify icon components and SVG framework.
 
-| Package                                  | Usage  |
-| ---------------------------------------- | ------ |
-| [SVG Framework](./components/iconify/)   | HTML   |
-| [React component](./components/react/)   | React  |
-| [Vue 3 component](./components/vue/)     | Vue 3  |
-| [Vue 2 component](./components/vue2/)    | Vue 2  |
-| [Svelte component](./components/svelte/) | Svelte |
-| [Ember component](./components/ember/)   | Ember  |
+| Package                                      | Usage  |
+| -------------------------------------------- | ------ |
+| [SVG Framework](./components/svg-framework/) | HTML   |
+| [React component](./components/react/)       | React  |
+| [Vue 3 component](./components/vue/)         | Vue 3  |
+| [Vue 2 component](./components/vue2/)        | Vue 2  |
+| [Svelte component](./components/svelte/)     | Svelte |
+| [Ember component](./components/ember/)       | Ember  |
 
 #### Deprecation notice
 


### PR DESCRIPTION
Noticed this while skimming the repository. The link to the SVG framework currently 404s.

Bisected to 7e2c345d7bbcd54d45c93d36693918ca22a5f62f. Looks like this happened when a directory was renamed.
