### PR TITLE
feat(vue): compatible with SSR

### DIFF
--- a/components/vue/src/iconify.ts
+++ b/components/vue/src/iconify.ts
@@ -243,6 +243,12 @@ export const Icon = defineComponent<IconProps>({
 	// Set initial data
 	data() {
 		return {
+			// Current icon name
+			_name: '',
+
+			// Loading
+			_loadingIcon: null,
+
 			// Mounted status
 			iconMounted: false,
 
@@ -252,12 +258,6 @@ export const Icon = defineComponent<IconProps>({
 	},
 
 	mounted() {
-		// Current icon name
-		this._name = '';
-
-		// Loading
-		this._loadingIcon = null;
-
 		// Mark as mounted
 		this.iconMounted = true;
 	},
@@ -354,7 +354,7 @@ export const Icon = defineComponent<IconProps>({
 		const props = this.$attrs;
 
 		// Get icon data
-		const icon: IconComponentData | null = this.iconMounted
+		const icon: IconComponentData | null = (this.iconMounted || props.ssr)
 			? this.getIcon(props.icon, props.onLoad)
 			: null;
 

--- a/components/vue/src/props.ts
+++ b/components/vue/src/props.ts
@@ -67,4 +67,9 @@ interface IconifyElementProps {
 /**
  * Mix of icon properties and HTMLElement properties
  */
-export type IconProps = IconifyElementProps & IconifyIconProps;
+export interface IconProps extends IconifyElementProps, IconifyIconProps {
+	/**
+	 * Try load icon on first render during SSR
+	 */
+	ssr?: boolean
+}

--- a/components/vue/src/props.ts
+++ b/components/vue/src/props.ts
@@ -70,6 +70,9 @@ interface IconifyElementProps {
 export interface IconProps extends IconifyElementProps, IconifyIconProps {
 	/**
 	 * Try load icon on first render during SSR
+	 *
+	 * This is a low-level API for framework integrations, you don't usually need to use it directly.
+	 * Note this might hydration mismatches if the icon data is not handled correctly, use with caution.
 	 */
 	ssr?: boolean
 }


### PR DESCRIPTION
In Nuxt, I am trying to find a good solution to render the icons in SSR to avoid the flicking.

I want to call `loadCollection` on server side and use the loaded data to render the SVG icons to SSR. Currently, it passes the icon data fetch with `this.iconMounted`, which is only `true` on the client side. This PR introduces a new `ssr` prop to the component to opt in for the first render and to be compatible with SSR.