### PR TITLE
Update Icon.svelte

### DIFF
--- a/components/svelte/src/Icon.svelte
+++ b/components/svelte/src/Icon.svelte
@@ -113,6 +113,6 @@ export {
 			{@html data.body}
 		</svg>
 	{:else}
-		<span {...data.attributes} />
+		<span {...data.attributes}></span>
 	{/if}
 {/if}


### PR DESCRIPTION
Svelte 5 [vite-plugin-svelte] /node_modules/@iconify/svelte/dist/Icon.svelte:116:2 Self-closing HTML tags for non-void elements are ambiguous — use `<span ...></span>` rather than `<span ... />`