### PR TITLE
chore: add iconify open collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: cyberalien
+open_collective: iconify
+github: [cyberalien]


### PR DESCRIPTION
We can create a new `.github` repo inside Iconify Org, adding the content in this PR, then remove all `.github/FUNDING.yml` from all repos excluding the new `.github` repo ofc.

You can check for example https://github.com/antfu-collective/.github

To see the changes in readme file, the PR must be merged.