### PR TITLE
fix: create component classes for tailwind plugin

### DIFF
--- a/plugins/tailwind/src/plugin.ts
+++ b/plugins/tailwind/src/plugin.ts
@@ -39,9 +39,23 @@ export function addDynamicIconSelectors(options?: DynamicIconifyPluginOptions) {
  * Usage in HTML: <span class="iconify mdi-light--home" />
  */
 export function addIconSelectors(options: IconifyPluginOptions) {
-	const rules = getCSSRulesForPlugin(options);
-	return plugin(({ addUtilities }) => {
-		addUtilities(rules);
+	const maskSelector =
+		'maskSelector' in options ? options.maskSelector : '.iconify';
+	const backgroundSelector =
+		'backgroundSelector' in options
+			? options.backgroundSelector
+			: '.iconify-color';
+	const {
+		[maskSelector]: iconify,
+		[backgroundSelector]: iconifyColor,
+		...icons
+	} = getCSSRulesForPlugin(options);
+	return plugin(({ addComponents, addUtilities }) => {
+		addComponents({
+			[maskSelector]: iconify,
+			[backgroundSelector]: iconifyColor,
+		});
+		addUtilities(icons);
 	});
 }
 


### PR DESCRIPTION
The mask and background selectors, which provide baseline styles for icons, should be component classes. That is the entire reason why component classes exist. Tailwind declares component classes first to allow utility classes to override them on a case-by-case basis.

Creating them as utility classes creates a specificity issue. When multiple selectors have the same specificity, the last declared selector has precedence. So when `.iconify` declares a width and height and its selector comes after `h-#` and `w-#` selectors in the build, it prevents overriding icon styles on a case-by-case basis.

This PR fixes the specificity issue by extracting the mask and background selectors and declaring them as components rather than utilities.