### PR TITLE
feat(utils): allow provide multiple `cwd` to node loader

### DIFF
--- a/packages/utils/src/loader/node-loader.ts
+++ b/packages/utils/src/loader/node-loader.ts
@@ -15,19 +15,28 @@ export const loadNodeIcon: UniversalIconLoader = async (
 		return result;
 	}
 
-	const iconSet = await loadCollectionFromFS(
-		collection,
-		options?.autoInstall,
-		undefined,
-		options?.cwd
-	);
-	if (iconSet) {
-		result = await searchForIcon(
-			iconSet,
+	const cwds = options?.cwd
+		? Array.isArray(options.cwd)
+			? options.cwd
+			: [options.cwd]
+		: [];
+
+	for (const cwd of cwds) {
+		const iconSet = await loadCollectionFromFS(
 			collection,
-			getPossibleIconNames(icon),
-			options
+			options?.autoInstall,
+			undefined,
+			cwd
 		);
+		if (iconSet) {
+			result = await searchForIcon(
+				iconSet,
+				collection,
+				getPossibleIconNames(icon),
+				options
+			);
+			if (result) break;
+		}
 	}
 
 	if (!result && options?.warn) {

--- a/packages/utils/src/loader/node-loader.ts
+++ b/packages/utils/src/loader/node-loader.ts
@@ -15,11 +15,7 @@ export const loadNodeIcon: UniversalIconLoader = async (
 		return result;
 	}
 
-	const cwds = options?.cwd
-		? Array.isArray(options.cwd)
-			? options.cwd
-			: [options.cwd]
-		: [];
+	const cwds = Array.isArray(options?.cwd) ? options.cwd : [options?.cwd];
 
 	for (const cwd of cwds) {
 		const iconSet = await loadCollectionFromFS(

--- a/packages/utils/src/loader/types.ts
+++ b/packages/utils/src/loader/types.ts
@@ -183,8 +183,11 @@ export type IconifyLoaderOptions = {
 	/**
 	 * Current working directory, used to resolve the @iconify-json package.
 	 *
+	 * Can be a string or an array of strings, the first existing path will be used.
+	 *
 	 * Only used on `node` environment.
+	 *
 	 * @default process.cwd()
 	 */
-	cwd?: string;
+	cwd?: string | string[];
 };


### PR DESCRIPTION
This PR allows an array to be passed as `cwd`. This node loader will try to load icons from each `cwd` one by one.

Motivation: when a CLI tool is installed globally, we need to load icons from both where the CLI is called (for user-installed icon sets) and where the CLI is installed (for pre-installed icon sets).