### PR TITLE
fix(react): Memoize offline components

### DIFF
--- a/components/react/src/offline.ts
+++ b/components/react/src/offline.ts
@@ -1,4 +1,4 @@
-import { forwardRef, createElement, type Ref } from 'react';
+import { forwardRef, createElement, memo, type Ref } from 'react';
 import type { IconifyIcon, IconifyJSON } from '@iconify/types';
 import type { IconifyIconSize } from '@iconify/utils/lib/customisations/defaults';
 import { defaultIconProps } from '@iconify/utils/lib/icon/defaults';
@@ -63,25 +63,25 @@ type IconComponentType = (props: IconProps) => JSX.Element;
  *
  * @param props - Component properties
  */
-export const Icon = forwardRef<IconElement, IconProps>((props, ref) =>
+export const Icon = memo(forwardRef<IconElement, IconProps>((props, ref) =>
 	IconComponent({
 		...props,
 		_ref: ref,
 	})
-) as IconComponentType;
+)) as IconComponentType;
 
 /**
  * Inline icon (has negative verticalAlign that makes it behave like icon font)
  *
  * @param props - Component properties
  */
-export const InlineIcon = forwardRef<IconElement, IconProps>((props, ref) =>
+export const InlineIcon = memo(forwardRef<IconElement, IconProps>((props, ref) =>
 	IconComponent({
 		inline: true,
 		...props,
 		_ref: ref,
 	})
-) as IconComponentType;
+)) as IconComponentType;
 
 /**
  * Add icon to storage, allowing to call it by name


### PR DESCRIPTION
There is no need to re-render the component (which recreates the SVG in the DOM) if the props did not change.

I didn't change the main components since I'm not sure if it is safe, and I don't use them in my project. I have patched the offline components in my project with this change and it fixes an issue where they are being re-rendered and breaking event handlers.