### PR TITLE
quickfix: Invalid icon name: "mdi&#45;&#45;delete"

### DIFF
--- a/plugins/tailwind/src/dynamic.ts
+++ b/plugins/tailwind/src/dynamic.ts
@@ -10,6 +10,7 @@ export function getDynamicCSSRules(
 	icon: string,
 	options: DynamicIconifyPluginOptions = {}
 ): Record<string, string> {
+    icon = icon.replace(/&#45;/g, '-');
 	const nameParts = icon.split(/--|\:/);
 	if (nameParts.length !== 2) {
 		throw new Error(`Invalid icon name: "${icon}"`);


### PR DESCRIPTION
one of icon names was somehow decimal encoded and I received that error every time I started local vite server.

My quick solution: 

replace &#45; with -