### PR TITLE
docs: fix descirption of addIconSelectors

### DIFF
--- a/plugins/tailwind/src/plugin.ts
+++ b/plugins/tailwind/src/plugin.ts
@@ -39,8 +39,6 @@ export function addDynamicIconSelectors(options?: DynamicIconifyPluginOptions) {
  *
  * Icons should combine either mask or background selector and icon selector
  *
- * This plugin generates only square icons. Icons that are not square will be resized to fit square.
- *
  * Usage in HTML: <span class="iconify mdi-light--home" />
  */
 export function addIconSelectors(options: IconifyPluginOptions) {


### PR DESCRIPTION
Description says that `addIconSelectors` only generates square icons, but it is not true. We can pass `options.square = false` to this function and it will allow non-square icons.
Option is already documented here: https://iconify.design/docs/usage/css/tailwind/iconify/#advanced-usage