### PR TITLE
feat(react): add fallback customization for Icon component

### DIFF
--- a/components/react/src/iconify.ts
+++ b/components/react/src/iconify.ts
@@ -338,7 +338,9 @@ function IconComponent(props: InternalIconProps): JSX.Element {
 	if (!data) {
 		return props.children
 			? (props.children as JSX.Element)
-			: createElement('span', {});
+			: props.fallback
+				? (props.fallback as JSX.Element)
+				: createElement('span', {});
 	}
 
 	return render(

--- a/components/react/src/props.ts
+++ b/components/react/src/props.ts
@@ -1,4 +1,4 @@
-import type { SVGProps, RefAttributes } from 'react';
+import type { SVGProps, RefAttributes, ReactNode } from 'react';
 import type { IconifyIcon } from '@iconify/types';
 import type { IconifyIconCustomisations as RawIconifyIconCustomisations } from '@iconify/utils/lib/customisations/defaults';
 import { defaultIconCustomisations } from '@iconify/utils/lib/customisations/defaults';
@@ -55,6 +55,10 @@ export interface IconifyIconProps extends IconifyIconCustomisations {
 
 	// If true, icon will be rendered without waiting for component to mount, such as when rendering on server side
 	ssr?: boolean;
+
+	// If present, icon will render the value of this property before the icon is loaded and rendered
+	// If not present, icon will render an empty span
+	fallback?: ReactNode;
 
 	// Callback to call when icon data has been loaded. Used only for icons loaded from API
 	onLoad?: IconifyIconOnLoad;


### PR DESCRIPTION


# Purpose

In the react component package, an Icon component will render an empty span as a placeholder. However, we may want to customize this behavior in a certain times. For example, the flickering caused by the delay of loading icons when using CSR.

# Solution

In this case, adding a custom fallback element allows to 'fix' this issue, as well as for more tailored customizations. Additionally, this is an optional property, so there's no need to worry about increasing the learning curve of API interface.

# Others

I'd love to update the docs as well if this feature got updated, just tell me if u need. Thanks!