### PR TITLE
chore: upgrade `@antfu/utils@9.2.0`

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -419,7 +419,7 @@
 	],
 	"dependencies": {
 		"@antfu/install-pkg": "^1.0.0",
-		"@antfu/utils": "^8.1.1",
+		"@antfu/utils": "^9.2.0",
 		"@iconify/types": "workspace:^",
 		"debug": "^4.4.0",
 		"globals": "^15.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,8 +745,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@antfu/utils':
-        specifier: ^8.1.1
-        version: 8.1.1
+        specifier: ^9.2.0
+        version: 9.2.0
       '@iconify/types':
         specifier: workspace:^
         version: link:../types
@@ -926,8 +926,8 @@ packages:
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
-  '@antfu/utils@8.1.1':
-    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
+  '@antfu/utils@9.2.0':
+    resolution: {integrity: sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -7884,7 +7884,7 @@ snapshots:
 
   '@antfu/utils@0.7.10': {}
 
-  '@antfu/utils@8.1.1': {}
+  '@antfu/utils@9.2.0': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:


### PR DESCRIPTION
close #388

It looks like there are no other major changes from `antfu/utils@8.1.1` to `antfu/utils@9.2.0` except Drop CJS and New filterInPlace function.