### PR TITLE
fix(utils): preserve iconToSVG sizing in loaders

### DIFF
--- a/packages/utils/src/loader/modern.ts
+++ b/packages/utils/src/loader/modern.ts
@@ -1,8 +1,11 @@
 import type { IconifyJSON, IconifyIcon } from '@iconify/types';
-import { iconToSVG, isUnsetKeyword } from '../svg/build';
+import { iconToSVG } from '../svg/build';
 import { getIconData } from '../icon-set/get-icon';
-import { calculateSize } from '../svg/size';
-import { mergeIconProps } from './utils';
+import {
+	loaderDefaultHeightProp,
+	loaderDefaultWidthProp,
+	mergeIconProps,
+} from './utils';
 import { defaultIconCustomisations } from '../customisations/defaults';
 import type { IconifyLoaderOptions } from './types';
 
@@ -35,7 +38,6 @@ export async function searchForIcon(
 				attributes: { width, height, ...restAttributes },
 				body,
 			} = iconToSVG(iconData, defaultCustomizations);
-			const scale = options?.scale;
 			return await mergeIconProps(
 				// DON'T remove space on <svg >
 				`<svg >${body}</svg>`,
@@ -43,47 +45,11 @@ export async function searchForIcon(
 				id,
 				options,
 				() => {
-					return { ...restAttributes };
-				},
-				(props) => {
-					// Check if value has 'unset' keyword
-					const check = (
-						prop: 'width' | 'height',
-						defaultValue: string | undefined
-					) => {
-						const propValue = props[prop];
-						let value: string | undefined;
-
-						if (!isUnsetKeyword(propValue)) {
-							if (propValue) {
-								// Do not change it
-								return;
-							}
-
-							if (typeof scale === 'number') {
-								// Scale icon, unless scale is 0
-								if (scale) {
-									value = calculateSize(
-										// Base on result from iconToSVG() or 1em
-										defaultValue ?? '1em',
-										scale
-									);
-								}
-							} else {
-								// Use result from iconToSVG()
-								value = defaultValue;
-							}
-						}
-
-						// Change / unset
-						if (!value) {
-							delete props[prop];
-						} else {
-							props[prop] = value;
-						}
+					return {
+						...restAttributes,
+						...(width ? { [loaderDefaultWidthProp]: width } : {}),
+						...(height ? { [loaderDefaultHeightProp]: height } : {}),
 					};
-					check('width', width);
-					check('height', height);
 				}
 			);
 		}

--- a/packages/utils/src/loader/utils.ts
+++ b/packages/utils/src/loader/utils.ts
@@ -2,9 +2,52 @@ import { isUnsetKeyword } from '../svg/build';
 import { calculateSize } from '../svg/size';
 import type { Awaitable, IconifyLoaderOptions } from './types';
 
-const svgWidthRegex = /\swidth\s*=\s*["']([\w.]+)["']/;
-const svgHeightRegex = /\sheight\s*=\s*["']([\w.]+)["']/;
+const svgWidthRegex = /\swidth\s*=\s*["']([^"']+)["']/;
+const svgHeightRegex = /\sheight\s*=\s*["']([^"']+)["']/;
+const svgViewBoxRegex = /\sviewBox\s*=\s*["']([^"']+)["']/;
 const svgTagRegex = /<svg\s+/;
+export const loaderDefaultWidthProp = '__iconify_loader_width';
+export const loaderDefaultHeightProp = '__iconify_loader_height';
+
+function stringifySize(value: string | number | undefined): string | undefined {
+	return value === undefined ? value : value.toString();
+}
+
+function getConfiguredSize(
+	source: string | undefined,
+	scale?: number
+): string | undefined {
+	if (typeof scale === 'number') {
+		return scale > 0 ? stringifySize(calculateSize(source ?? '1em', scale)) : undefined;
+	}
+	return source;
+}
+
+function getSvgAspectRatio(
+	svgNode: string,
+	props: Record<string, string>
+): number | undefined {
+	const viewBox = props.viewBox ?? svgViewBoxRegex.exec(svgNode)?.[1];
+	if (!viewBox) {
+		return;
+	}
+
+	const values = viewBox
+		.trim()
+		.split(/[\s,]+/)
+		.map((value) => parseFloat(value));
+	if (values.length !== 4 || values.some((value) => !Number.isFinite(value))) {
+		return;
+	}
+
+	const width = values[2];
+	const height = values[3];
+	if (width <= 0 || height <= 0) {
+		return;
+	}
+
+	return width / height;
+}
 
 function configureSvgSize(
 	svg: string,
@@ -12,33 +55,67 @@ function configureSvgSize(
 	scale?: number
 ): [boolean, boolean] {
 	const svgNode = svg.slice(0, svg.indexOf('>'));
+	const widthOnSvg = svgWidthRegex.test(svgNode);
+	const heightOnSvg = svgHeightRegex.test(svgNode);
+	const defaultWidth =
+		props[loaderDefaultWidthProp] ?? svgWidthRegex.exec(svgNode)?.[1];
+	const defaultHeight =
+		props[loaderDefaultHeightProp] ?? svgHeightRegex.exec(svgNode)?.[1];
+	const aspectRatio = getSvgAspectRatio(svgNode, props);
+	delete props[loaderDefaultWidthProp];
+	delete props[loaderDefaultHeightProp];
 
-	const check = (prop: 'width' | 'height', regex: RegExp): boolean => {
-		const result = regex.exec(svgNode);
-		const isSet = result != null;
+	const customWidth = props.width;
+	const customHeight = props.height;
+	const hasCustomWidth = !!customWidth || isUnsetKeyword(customWidth);
+	const hasCustomHeight = !!customHeight || isUnsetKeyword(customHeight);
 
-		const propValue = props[prop];
-
-		if (!propValue && !isUnsetKeyword(propValue)) {
-			if (typeof scale === 'number') {
-				// Scale icon, unless scale is 0
-				if (scale > 0) {
-					props[prop] = calculateSize(
-						// Base on result from iconToSVG() or 1em
-						result?.[1] ?? '1em',
-						scale
-					);
-				}
-			} else if (result) {
-				// Use result from iconToSVG()
-				props[prop] = result[1];
+	if (hasCustomWidth || hasCustomHeight) {
+		if (!hasCustomWidth) {
+			if (isUnsetKeyword(customHeight)) {
+				delete props.width;
+				delete props.height;
+			} else if (aspectRatio) {
+				props.width = stringifySize(
+					calculateSize(customHeight as string, aspectRatio)
+				) as string;
+				props.height = customHeight as string;
+			} else {
+				delete props.width;
+			}
+		} else if (isUnsetKeyword(customWidth)) {
+			delete props.width;
+			if (!hasCustomHeight || isUnsetKeyword(customHeight)) {
+				delete props.height;
 			}
 		}
 
-		return isSet;
-	};
+		if (!hasCustomHeight) {
+			if (isUnsetKeyword(customWidth)) {
+				delete props.height;
+			} else if (aspectRatio) {
+				props.height = stringifySize(
+					calculateSize(customWidth as string, 1 / aspectRatio)
+				) as string;
+				props.width = customWidth as string;
+			} else {
+				delete props.height;
+			}
+		} else if (isUnsetKeyword(customHeight)) {
+			delete props.height;
+		}
+	} else {
+		const width = getConfiguredSize(defaultWidth, scale);
+		const height = getConfiguredSize(defaultHeight, scale);
+		if (width) {
+			props.width = width;
+		}
+		if (height) {
+			props.height = height;
+		}
+	}
 
-	return [check('width', svgWidthRegex), check('height', svgHeightRegex)];
+	return [widthOnSvg, heightOnSvg];
 }
 
 export async function mergeIconProps(

--- a/packages/utils/tests/get-custom-icon-test.ts
+++ b/packages/utils/tests/get-custom-icon-test.ts
@@ -154,4 +154,66 @@ describe('Testing getCustomIcon', () => {
 			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 120"><circle cx="45" cy="60" r="30"/></svg>'
 		);
 	});
+
+	test('CustomIconLoader recalculates width from explicit height', async () => {
+		const svg =
+			'<svg viewBox="0 0 640 512"><path d="M0 0h640v512H0z"/></svg>';
+		const result = await getCustomIcon(() => svg, 'a', 'b', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					height: '2em',
+				},
+			},
+		});
+		expect(result && result.includes('width="2.5em"')).toBeTruthy();
+		expect(result && result.includes('height="2em"')).toBeTruthy();
+	});
+
+	test('CustomIconLoader recalculates height from explicit width', async () => {
+		const svg =
+			'<svg viewBox="0 0 640 512"><path d="M0 0h640v512H0z"/></svg>';
+		const result = await getCustomIcon(() => svg, 'a', 'b', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					width: '2em',
+				},
+			},
+		});
+		expect(result && result.includes('width="2em"')).toBeTruthy();
+		expect(result && result.includes('height="1.6em"')).toBeTruthy();
+	});
+
+	test('CustomIconLoader omits suppressed dimensions', async () => {
+		const svg =
+			'<svg viewBox="0 0 640 512"><path d="M0 0h640v512H0z"/></svg>';
+		const result = await getCustomIcon(() => svg, 'a', 'b', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					width: 'unset',
+					height: 'none',
+				},
+			},
+		});
+		expect(result && result.includes('width="')).toBeFalsy();
+		expect(result && result.includes('height="')).toBeFalsy();
+	});
+
+	test('CustomIconLoader keeps explicit value while omitting suppressed side', async () => {
+		const svg =
+			'<svg viewBox="0 0 640 512"><path d="M0 0h640v512H0z"/></svg>';
+		const result = await getCustomIcon(() => svg, 'a', 'b', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					width: 'unset',
+					height: '2em',
+				},
+			},
+		});
+		expect(result && result.includes('width="')).toBeFalsy();
+		expect(result && result.includes('height="2em"')).toBeTruthy();
+	});
 });

--- a/packages/utils/tests/iconify-icon-test.ts
+++ b/packages/utils/tests/iconify-icon-test.ts
@@ -104,7 +104,7 @@ describe('Testing loadNodeIcon', () => {
 		});
 		expect(result).toBeTruthy();
 		expect(result && result.includes('width="')).toBeFalsy();
-		expect(result && result.includes('height="1em"')).toBeTruthy();
+		expect(result && result.includes('height="')).toBeFalsy();
 	});
 
 	test('loadIcon with custom width/height', async () => {
@@ -157,7 +157,7 @@ describe('Testing loadNodeIcon', () => {
 			},
 		});
 		expect(result).toBeTruthy();
-		expect(result && result.includes('width="')).toBeFalsy();
+		expect(result && result.includes('width="1em"')).toBeTruthy();
 		expect(result && result.includes('height="1em"')).toBeTruthy();
 	});
 
@@ -189,5 +189,72 @@ describe('Testing loadNodeIcon', () => {
 		expect(result).toBeTruthy();
 		expect(result && result.includes('width="0.75em"')).toBeTruthy();
 		expect(result && result.includes('height="1em"')).toBeTruthy();
+	});
+
+	test('loadIcon preserves default sizing for non-square icon', async () => {
+		const result = await loadNodeIcon('fa6-regular', 'comments', {
+			scale: 1.2,
+		});
+		expect(result).toBeTruthy();
+		expect(result && result.includes('width="1.5em"')).toBeTruthy();
+		expect(result && result.includes('height="1.2em"')).toBeTruthy();
+	});
+
+	test('loadIcon recalculates width from explicit height', async () => {
+		const result = await loadNodeIcon('fa6-regular', 'comments', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					height: '2em',
+				},
+			},
+		});
+		expect(result).toBeTruthy();
+		expect(result && result.includes('height="2em"')).toBeTruthy();
+		expect(result && result.includes('width="2.5em"')).toBeTruthy();
+	});
+
+	test('loadIcon recalculates height from explicit width', async () => {
+		const result = await loadNodeIcon('fa6-regular', 'comments', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					width: '2em',
+				},
+			},
+		});
+		expect(result).toBeTruthy();
+		expect(result && result.includes('width="2em"')).toBeTruthy();
+		expect(result && result.includes('height="1.6em"')).toBeTruthy();
+	});
+
+	test('loadIcon omits suppressed dimensions', async () => {
+		const result = await loadNodeIcon('fa6-regular', 'comments', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					width: 'unset',
+					height: 'unset',
+				},
+			},
+		});
+		expect(result).toBeTruthy();
+		expect(result && result.includes('width="')).toBeFalsy();
+		expect(result && result.includes('height="')).toBeFalsy();
+	});
+
+	test('loadIcon keeps explicit value while omitting suppressed side', async () => {
+		const result = await loadNodeIcon('fa6-regular', 'comments', {
+			scale: 1.2,
+			customizations: {
+				additionalProps: {
+					width: 'unset',
+					height: '2em',
+				},
+			},
+		});
+		expect(result).toBeTruthy();
+		expect(result && result.includes('width="')).toBeFalsy();
+		expect(result && result.includes('height="2em"')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Problem

`@iconify/utils` loader output was not preserving `iconToSVG()` sizing semantics.

After `iconToSVG()` computed the correct `width` / `height`, the loader path merged dimensions again in a way that:
- failed to recalculate the opposite side when only `width` or only `height` was explicitly set
- reintroduced `width` / `height` after `unset` / `none` had suppressed them

This affected both standard Iconify collections and custom SVG collections.

## Proposed fix

Move width/height resolution into the shared loader sizing logic and make it compute dimensions as a coupled pair from the SVG/viewBox aspect ratio.

The loader now:
- preserves existing default sizing when no explicit override is provided
- recalculates the missing side correctly for width-only or height-only overrides
- preserves `unset` / `none` suppression instead of filling dimensions back in later
- applies the same behavior to both modern and custom loader paths

## Breaking changes

No intended API breaking changes.

Behavior changes only in cases that were previously inconsistent or incorrect:
- width-only and height-only overrides now recalculate the other dimension correctly
- `unset` / `none` now truly suppress root `width` / `height` instead of being reintroduced later

Fixes https://github.com/unplugin/unplugin-icons/issues/353
Closes https://github.com/unplugin/unplugin-icons/pull/433