### PR TITLE
fix(vue): prevent `customise` prop from leaking onto rendered svg element

### DIFF
--- a/components/vue/src/render.ts
+++ b/components/vue/src/render.ts
@@ -128,6 +128,7 @@ export const render = (
 			case 'onLoad':
 			case 'mode':
 			case 'ssr':
+			case 'customise':
 				break;
 
 			// Boolean attributes


### PR DESCRIPTION
Resolves #3529 