### PR TITLE
Fix @iconify/svelte helper export paths

### DIFF
--- a/components/svelte/package.json
+++ b/components/svelte/package.json
@@ -29,14 +29,14 @@
 			"types": "./dist/offline.d.ts"
 		},
 		"./dist/functions": {
-			"types": "./lib/dist/functions.d.ts",
-			"require": "./lib/dist/functions.cjs",
-			"import": "./lib/dist/functions.js"
+			"types": "./dist/functions.d.ts",
+			"require": "./dist/functions.cjs",
+			"import": "./dist/functions.js"
 		},
 		"./dist/offline-functions": {
-			"types": "./lib/dist/offline-functions.d.ts",
-			"require": "./lib/dist/offline-functions.cjs",
-			"import": "./lib/dist/offline-functions.js"
+			"types": "./dist/offline-functions.d.ts",
+			"require": "./dist/offline-functions.cjs",
+			"import": "./dist/offline-functions.js"
 		},
 		"./*": "./*"
 	},


### PR DESCRIPTION
﻿## Summary

`@iconify/svelte` ships the helper bundles under `dist/`, but the explicit extless helper exports currently point at `lib/dist/`.

This updates the `./dist/functions` and `./dist/offline-functions` export targets to the files that are already built and included in the package:

- `./dist/functions.{js,cjs,d.ts}`
- `./dist/offline-functions.{js,cjs,d.ts}`

## Why

With the current published package metadata, clean installs fail for extless helper imports such as:

```js
await import('@iconify/svelte/dist/functions');
require('@iconify/svelte/dist/functions');
```

Those resolve through the explicit export map to missing `lib/dist/*` files. The explicit file imports already work because the package does ship the matching files in `dist/`.

## Validation

- `npm view @iconify/svelte@5.2.1 name version repository license exports --json`
- `npm pack @iconify/svelte@5.2.1 --dry-run --json`
- Confirmed the published package includes the `dist/*` helper files and does not include the exported `lib/dist/*` targets.
- Reproduced the current clean-install failure for `import('@iconify/svelte/dist/functions')` with `ERR_MODULE_NOT_FOUND` against `lib/dist/functions.js`.
- Applied this same package export change to the published tarball in a temp directory, installed it, and verified:
  - `import('@iconify/svelte/dist/functions')`
  - `require('@iconify/svelte/dist/functions')`
  - `import('@iconify/svelte/dist/offline-functions')`
  - `require('@iconify/svelte/dist/offline-functions')`
- `node -e "JSON.parse(require('fs').readFileSync('components/svelte/package.json','utf8'))"`
- `git diff --check`

Note: I also attempted a local `pnpm --filter @iconify/svelte run build`. After building the workspace dependencies, it still fails on unrelated current workspace TypeScript/type-resolution errors, including `src/render.ts` strict index errors and workspace `.d.ts` resolution errors. This PR only changes the package export metadata.
