### PR TITLE
fix(utils): escape ':' and '/' when encoding SVG for CSS url()

### DIFF
--- a/components/react/tests/iconify/10-style-mode.test.ts
+++ b/components/react/tests/iconify/10-style-mode.test.ts
@@ -27,7 +27,7 @@ describe('Rendering as span', () => {
 		// Depending on version of jsdom, "currentColor" may be converted to "currentcolor"
 		const currentColor = html.includes('currentcolor') ? 'currentcolor' : 'currentColor';
 		expect(html).toEqual(
-			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'/%3E%3C/svg%3E&quot;); width: 1em; height: 1em; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
+			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'%2F%3E%3C%2Fsvg%3E&quot;); width: 1em; height: 1em; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
 		);
 	});
 
@@ -50,7 +50,7 @@ describe('Rendering as span', () => {
 		// Depending on version of jsdom, "currentColor" may be converted to "currentcolor"
 		const currentColor = html.includes('currentcolor') ? 'currentcolor' : 'currentColor';
 		expect(html).toEqual(
-			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'/%3E%3C/svg%3E&quot;); width: 32px; height: 48px; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
+			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'%2F%3E%3C%2Fsvg%3E&quot;); width: 32px; height: 48px; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
 		);
 	});
 });

--- a/components/svelte/tests/iconify/10-style-mode.test.ts
+++ b/components/svelte/tests/iconify/10-style-mode.test.ts
@@ -29,7 +29,7 @@ describe('Rendering as span', () => {
 			? 'currentcolor'
 			: 'currentColor';
 		expect(html).toBe(
-			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'/%3E%3C/svg%3E&quot;); width: 1em; height: 1em; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
+			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'%2F%3E%3C%2Fsvg%3E&quot;); width: 1em; height: 1em; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
 		);
 	});
 
@@ -55,7 +55,7 @@ describe('Rendering as span', () => {
 			? 'currentcolor'
 			: 'currentColor';
 		expect(html).toBe(
-			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'/%3E%3C/svg%3E&quot;); width: 48px; height: 32px; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
+			`<span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z' fill='currentColor'%2F%3E%3C%2Fsvg%3E&quot;); width: 48px; height: 32px; display: inline-block; background-color: ${currentColor}; mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
 		);
 	});
 });

--- a/iconify-icon/icon/tests/component-test.ts
+++ b/iconify-icon/icon/tests/component-test.ts
@@ -205,7 +205,7 @@ describe('Testing icon component', () => {
 		// Should render SPAN, with comment
 		expect(node.status).toBe('rendered');
 		const renderedIconWithComment =
-			"<span style=\"--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Crect width='10' height='10'%3E%3Canimate attributeName='width' values='10;5;10' dur='10s' repeatCount='indefinite' /%3E%3C/rect%3E%3C!-- --%3E%3C/svg%3E&quot;); width: 1em; height: 1em; background-color: transparent; background-image: var(--svg); background-repeat: no-repeat; background-size: 100% 100%;\"></span>";
+			"<span style=\"--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' viewBox='0 0 16 16'%3E%3Crect width='10' height='10'%3E%3Canimate attributeName='width' values='10;5;10' dur='10s' repeatCount='indefinite' %2F%3E%3C%2Frect%3E%3C!-- --%3E%3C%2Fsvg%3E&quot;); width: 1em; height: 1em; background-color: transparent; background-image: var(--svg); background-repeat: no-repeat; background-size: 100% 100%;\"></span>";
 		const html1 = node._shadowRoot.innerHTML;
 		expect(html1.replace(/-- [0-9]+ --/, '-- --')).toBe(
 			`${styleOpeningTag}${expectedBlock}</style>${renderedIconWithComment}`

--- a/iconify-icon/icon/tests/render-icon-test.ts
+++ b/iconify-icon/icon/tests/render-icon-test.ts
@@ -133,7 +133,7 @@ describe('Testing rendering loaded icon', () => {
 		// Depending on version of jsdom, "-webkit" styles may be included or not
 		const hasWebkit = node.innerHTML.includes('-webkit-mask-image');
 		expect(node.innerHTML).toBe(
-			`${styleOpeningTag}${expectedInline}</style><span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cg /%3E%3C/svg%3E&quot;); width: 1em; height: 1em; background-color: ${currentColor};${hasWebkit ? ' -webkit-mask-image: var(--svg); -webkit-mask-repeat: no-repeat; -webkit-mask-size: 100% 100%;' : ''} mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
+			`${styleOpeningTag}${expectedInline}</style><span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cg %2F%3E%3C%2Fsvg%3E&quot;); width: 1em; height: 1em; background-color: ${currentColor};${hasWebkit ? ' -webkit-mask-image: var(--svg); -webkit-mask-repeat: no-repeat; -webkit-mask-size: 100% 100%;' : ''} mask-image: var(--svg); mask-repeat: no-repeat; mask-size: 100% 100%;"></span>`
 		);
 
 		// Change mode to background, add some customisations
@@ -156,7 +156,7 @@ describe('Testing rendering loaded icon', () => {
 
 		// Test HTML
 		expect(node.innerHTML).toBe(
-			`${styleOpeningTag}${expectedInline}</style><span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cg /%3E%3C/svg%3E&quot;); width: 24px; height: 24px; background-color: transparent; background-image: var(--svg); background-repeat: no-repeat; background-size: 100% 100%;"></span>`
+			`${styleOpeningTag}${expectedInline}</style><span style="--svg: url(&quot;data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cg %2F%3E%3C%2Fsvg%3E&quot;); width: 24px; height: 24px; background-color: transparent; background-image: var(--svg); background-repeat: no-repeat; background-size: 100% 100%;"></span>`
 		);
 	});
 });

--- a/packages/utils/src/svg/url.ts
+++ b/packages/utils/src/svg/url.ts
@@ -10,11 +10,20 @@ export function encodeSVGforURL(svg: string): string {
 			.replace(/"/g, "'")
 			.replace(/%/g, '%25')
 			.replace(/#/g, '%23')
-			// .replace(/{/g, '%7B') // not needed in string inside double quotes
-			// .replace(/}/g, '%7D') // not needed in string inside double quotes
 			.replace(/</g, '%3C')
 			.replace(/>/g, '%3E')
 			.replace(/\s+/g, ' ') // Replace all whitespace with space to get rid of '\r', '\n' and '\t'
+			// .replace(/{/g, '%7B') // not needed in string inside double quotes
+			// .replace(/}/g, '%7D') // not needed in string inside double quotes
+			// Some reverse proxies blindly rewrite every "http://" occurrence in
+			// served text to "https://" to avoid mixed content warnings. Left
+			// unescaped, a literal "http://" can survive inside the encoded SVG
+			// (most commonly from an injected `xmlns="http://www.w3.org/2000/svg"`)
+			// and get corrupted by such rewrites, breaking the SVG namespace.
+			// Escaping ':' and '/' removes that substring while staying fully
+			// reversible by the browser's normal data URI percent-decoding.
+			.replace(/:/g, '%3A')
+			.replace(/\//g, '%2F')
 	);
 }
 

--- a/packages/utils/tests/encode-svg-for-css-test.ts
+++ b/packages/utils/tests/encode-svg-for-css-test.ts
@@ -1,0 +1,40 @@
+import { encodeSvgForCss } from '../lib/svg/encode-svg-for-css';
+
+describe('Encoding SVG for CSS', () => {
+	test('Injects xmlns when missing', () => {
+		const svg =
+			'<svg viewBox="0 0 16 16" width="16" height="16"><path d="M0 0h16v16z" /></svg>';
+		expect(encodeSvgForCss(svg)).toBe(
+			"%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 0h16v16z' %2F%3E%3C%2Fsvg%3E"
+		);
+	});
+
+	test('Injects xmlns:xlink when xlink: is used', () => {
+		const svg = '<svg viewBox="0 0 16 16"><use xlink:href="#icon" /></svg>';
+		expect(encodeSvgForCss(svg)).toBe(
+			"%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' xmlns%3Axlink='http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink' viewBox='0 0 16 16'%3E%3Cuse xlink%3Ahref='%23icon' %2F%3E%3C%2Fsvg%3E"
+		);
+	});
+
+	test('Does not touch an existing xmlns', () => {
+		const svg =
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M0 0h16v16z" /></svg>';
+		expect(encodeSvgForCss(svg)).toBe(
+			"%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox='0 0 16 16'%3E%3Cpath d='M0 0h16v16z' %2F%3E%3C%2Fsvg%3E"
+		);
+	});
+
+	test('Regression: never leaks a literal "http://" or "https://" substring', () => {
+		// This is the bug this escaping fixes: some reverse proxies blindly
+		// rewrite every "http://" occurrence in served text to "https://" to
+		// avoid mixed content warnings. Since icon sets normally don't carry
+		// their own xmlns, encodeSvgForCss injects
+		// `xmlns="http://www.w3.org/2000/svg"` on practically every icon --
+		// left unescaped, that substring would survive into the output and
+		// get corrupted by such a rewrite, breaking the SVG namespace.
+		const svg = '<svg viewBox="0 0 16 16"><path d="M0 0h16v16z" /></svg>';
+		const encoded = encodeSvgForCss(svg);
+		expect(encoded).not.toContain('http://');
+		expect(encoded).not.toContain('https://');
+	});
+});

--- a/packages/utils/tests/encode-url-test.ts
+++ b/packages/utils/tests/encode-url-test.ts
@@ -8,7 +8,7 @@ describe('Testing generating url()', () => {
 			'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M0 0h16v16z" fill="#f80" /></svg>';
 		const url = svgToURL(html);
 		expect(url).toBe(
-			"url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M0 0h16v16z' fill='%23f80' /%3E%3C/svg%3E\")"
+			"url(\"data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M0 0h16v16z' fill='%23f80' %2F%3E%3C%2Fsvg%3E\")"
 		);
 	});
 
@@ -17,7 +17,7 @@ describe('Testing generating url()', () => {
 			'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><style>path { fill: #f80; }</style><path d="M0 0h16v16z" /></svg>';
 		const url = svgToURL(html);
 		expect(url).toBe(
-			"url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cstyle%3Epath { fill: %23f80; }%3C/style%3E%3Cpath d='M0 0h16v16z' /%3E%3C/svg%3E\")"
+			"url(\"data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cstyle%3Epath { fill%3A %23f80; }%3C%2Fstyle%3E%3Cpath d='M0 0h16v16z' %2F%3E%3C%2Fsvg%3E\")"
 		);
 	});
 
@@ -33,7 +33,21 @@ describe('Testing generating url()', () => {
 </svg>`;
 		const url = svgToURL(trimSVG(html));
 		expect(url).toBe(
-			"url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Crect x='2' y='2' width='20' height='10' fill='currentColor'%3E%3Canimate id='animation1' attributeName='height' values='10;5' dur='0.5s' fill='freeze'/%3E%3Canimate id='animation2' attributeName='width' values='20;5' dur='0.2s' begin='animation1.end+1s' fill='freeze'/%3E%3C/rect%3E%3Crect x='2' y='12' width='20' height='5' fill='currentColor'%3E%3Canimate attributeName='height' values='5;10;5' begin='animation1.end+0.2s;animation2.end-0.2s' dur='0.3s'/%3E%3C/rect%3E%3C/svg%3E\")"
+			"url(\"data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='24' height='24' viewBox='0 0 24 24'%3E%3Crect x='2' y='2' width='20' height='10' fill='currentColor'%3E%3Canimate id='animation1' attributeName='height' values='10;5' dur='0.5s' fill='freeze'%2F%3E%3Canimate id='animation2' attributeName='width' values='20;5' dur='0.2s' begin='animation1.end+1s' fill='freeze'%2F%3E%3C%2Frect%3E%3Crect x='2' y='12' width='20' height='5' fill='currentColor'%3E%3Canimate attributeName='height' values='5;10;5' begin='animation1.end+0.2s;animation2.end-0.2s' dur='0.3s'%2F%3E%3C%2Frect%3E%3C%2Fsvg%3E\")"
 		);
+	});
+
+	test('Does not leak a literal "http://" or "https://" substring', () => {
+		// Regression test: some reverse proxies blindly rewrite every "http://"
+		// occurrence in served text to "https://" to avoid mixed content
+		// warnings. An unescaped ':' or '/' would let a literal "http://" survive
+		// inside the encoded SVG (most commonly from an injected
+		// `xmlns="http://www.w3.org/2000/svg"`), where such a rewrite would
+		// corrupt it and break the SVG namespace.
+		const html =
+			'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><path d="M0 0h16v16z" /></svg>';
+		const url = svgToURL(html);
+		expect(url).not.toContain('http://');
+		expect(url).not.toContain('https://');
 	});
 });


### PR DESCRIPTION
Some reverse proxies blindly rewrite every "http://" occurrence in served text to "https://" to avoid mixed content warnings. Left unescaped, a literal "http://" can survive inside the SVG encoded by encodeSVGforURL (like `xmlns="http://www.w3.org/2000/svg"`) that encodeSvgForCss (and consumers building their own markup) inject, since icon sets normally don't carry their own xmlns. Such a rewrite corrupts that substring and breaks the SVG namespace, so the icon fails to render (I've been debugging this for like a week 😅).

Escaping ':' and '/' removes the substring while staying fully reversible by the browser's normal data URI percent-decoding, so this is safe to always apply and it makes iconify (and its consumers, like UnoCSS) work perfectly even with misconfigured browsers, while keeping the original purpose of this function to provide the best size (in contrast with encodeURIComponent).

This of course adds a bit of storage overhead, but it's negligible and I think it's better to cover much more edge cases for users.