### PR TITLE
fix(vue): support boolean attribute shorthand casting and normalize flip precedence

### DIFF
--- a/components/vue/src/iconify.ts
+++ b/components/vue/src/iconify.ts
@@ -6,6 +6,8 @@ import {
 	shallowRef,
 	nextTick,
 	watch,
+	PropType,
+	ComponentObjectPropsOptions,
 } from 'vue';
 import type { IconifyJSON, IconifyIcon } from '@iconify/types';
 
@@ -378,30 +380,30 @@ export const Icon = defineComponent<IconProps>(
 		};
 	},
 	{
-		props: [
+		props: {
 			// Icon and render mode
-			'icon',
-			'mode',
-			'ssr',
+			icon: { type: [String, Object] as PropType<IconProps['icon']>, required: true },
+			mode: { type: String as PropType<IconProps['mode']> },
+			ssr: { type: Boolean },
 			// Layout and style
-			'width',
-			'height',
-			'style',
-			'color',
-			'inline',
+			width: { type: [String, Number] },
+			height: { type: [String, Number] },
+			style: { type: [String, Object] },
+			color: { type: String },
+			inline: { type: Boolean },
 			// Transformations
-			'rotate',
-			'hFlip',
-			'horizontalFlip',
-			'vFlip',
-			'verticalFlip',
-			'flip',
+			rotate: { type: [Number, String] as PropType<IconProps['rotate']> },
+			hFlip: { type: Boolean },
+			horizontalFlip: { type: Boolean },
+			vFlip: { type: Boolean },
+			verticalFlip: { type: Boolean },
+			flip: { type: String },
 			// Misc
-			'id',
-			'ariaHidden',
-			'customise',
-			'title',
-		],
+			id: { type: String },
+			ariaHidden: { type: Boolean, default: undefined },
+			customise: { type: Function as PropType<IconProps['customise']> },
+			title: { type: String },
+		} satisfies Required<ComponentObjectPropsOptions<IconProps>>,
 		emits: ['load'],
 	}
 );

--- a/components/vue/src/offline.ts
+++ b/components/vue/src/offline.ts
@@ -1,4 +1,4 @@
-import { defineComponent, renderSlot } from 'vue';
+import { ComponentObjectPropsOptions, defineComponent, PropType, renderSlot } from 'vue';
 import type { IconifyIcon, IconifyJSON } from '@iconify/types';
 import type { IconifyIconSize } from '@iconify/utils/lib/customisations/defaults';
 import { defaultIconProps } from '@iconify/utils/lib/icon/defaults';
@@ -99,29 +99,30 @@ export const Icon = defineComponent<IconProps>(
 		};
 	},
 	{
-		props: [
+		props: {
 			// Icon and render mode
-			'icon',
-			'mode',
-			'ssr',
+			icon: { type: [String, Object] as PropType<IconProps['icon']>, required: true },
+			mode: { type: String as PropType<IconProps['mode']> },
+			ssr: { type: Boolean },
 			// Layout and style
-			'width',
-			'height',
-			'style',
-			'color',
-			'inline',
+			width: { type: [String, Number] },
+			height: { type: [String, Number] },
+			style: { type: [String, Object] },
+			color: { type: String },
+			inline: { type: Boolean },
 			// Transformations
-			'rotate',
-			'hFlip',
-			'horizontalFlip',
-			'vFlip',
-			'verticalFlip',
-			'flip',
+			rotate: { type: [Number, String] as PropType<IconProps['rotate']> },
+			hFlip: { type: Boolean },
+			horizontalFlip: { type: Boolean },
+			vFlip: { type: Boolean },
+			verticalFlip: { type: Boolean },
+			flip: { type: String },
 			// Misc
-			'id',
-			'ariaHidden',
-			'customise',
-			'title',
-		],
+			id: { type: String },
+			ariaHidden: { type: Boolean, default: undefined },
+			customise: { type: Function as PropType<IconProps['customise']> },
+			title: { type: String },
+
+		} satisfies Required<ComponentObjectPropsOptions<IconProps>>,
 	}
 );

--- a/components/vue/src/render.ts
+++ b/components/vue/src/render.ts
@@ -140,10 +140,8 @@ export const render = (
 				break;
 
 			// Flip as string: 'horizontal,vertical'
+			// Handled after this loop, see below.
 			case 'flip':
-				if (typeof value === 'string') {
-					flipFromString(customisations, value);
-				}
 				break;
 
 			// Color: override style
@@ -182,6 +180,13 @@ export const render = (
 				}
 			}
 		}
+	}
+
+	// Apply flip shorthand ('horizontal,vertical') after all conflicting 
+	// explicit hFlip/vFlip props are processed.
+	// It only sets hFlip/vFlip to `true`, never `false`.
+	if (typeof props.flip === 'string') {
+		flipFromString(customisations, props.flip);
 	}
 
 	// Generate icon

--- a/components/vue/tests/iconify/10-basic-test.ts
+++ b/components/vue/tests/iconify/10-basic-test.ts
@@ -70,7 +70,7 @@ describe('Creating component', () => {
 		await nextTick();
 
 		expect(wrapper.html().replace(/\s*\n\s*/g, '')).toBe(
-			`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="iconify iconify--${prefix}"><path d="M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z" fill="currentColor"></path></svg>`
+			`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--${prefix}" width="1em" height="1em" viewBox="0 0 24 24"><path d="M4 19h16v2H4zm5-4h11v2H9zm-5-4h16v2H4zm0-8h16v2H4zm5 4h11v2H9z" fill="currentColor"></path></svg>`
 		);
 	});
 });

--- a/components/vue/tests/iconify/20-attributes-test.ts
+++ b/components/vue/tests/iconify/20-attributes-test.ts
@@ -66,6 +66,24 @@ describe('Passing attributes', () => {
 		expect(wrapper.html()).not.toContain('aria-hidden="true"');
 	});
 
+	test('ariaHidden shorthands', async () => {
+		// camelCase, boolean value
+		const Wrapper = {
+			components: { Icon },
+			template: `<Icon :icon="icon" ariaHidden />`,
+			data() {
+				return {
+					icon: iconData,
+				};
+			},
+		};
+
+		const wrapper = mount(Wrapper, {});
+		await nextTick();
+
+		expect(wrapper.html()).toContain('aria-hidden="true"');
+	});
+
 	test('style as string', async () => {
 		const Wrapper = {
 			components: { Icon },

--- a/components/vue/tests/iconify/20-inline-test.ts
+++ b/components/vue/tests/iconify/20-inline-test.ts
@@ -9,6 +9,23 @@ const iconData = {
 };
 
 describe('Inline attribute', () => {
+	test('shorthands', async () => {
+		const Wrapper = {
+			components: { Icon },
+			template: `<Icon :icon="icon" inline />`,
+			data() {
+				return {
+					icon: iconData,
+				};
+			},
+		};
+
+		const wrapper = mount(Wrapper, {});
+		await nextTick();
+
+		expect(wrapper.html()).toContain('style="vertical-align: -0.125em;"');
+	});
+
 	test('string', async () => {
 		const Wrapper = {
 			components: { Icon },

--- a/components/vue/tests/iconify/20-transformations-test.ts
+++ b/components/vue/tests/iconify/20-transformations-test.ts
@@ -116,10 +116,32 @@ describe('Flip', () => {
 	});
 
 	test('shorthand and boolean', async () => {
-		// 'flip' is processed after 'hFlip' because of order of elements in object, overwriting value
+		// hFlip=false conflicts with flip="horizontal": a `true` from either
+		// source always wins over a conflicting `false`, regardless of
+		// attribute/prop order
 		const Wrapper = {
 			components: { Icon },
 			template: `<Icon :icon="icon" :hFlip="false" flip="horizontal" />`,
+			data() {
+				return {
+					icon: iconData,
+				};
+			},
+		};
+
+		const wrapper = mount(Wrapper, {});
+		await nextTick();
+
+		expect(wrapper.html()).toContain('<g transform="translate(24 0) scale(-1 1)">');
+	});
+
+	test('shorthand and boolean reversed', async () => {
+		// hFlip=false conflicts with flip="horizontal": a `true` from either
+		// source always wins over a conflicting `false`, regardless of
+		// attribute/prop order
+		const Wrapper = {
+			components: { Icon },
+			template: `<Icon :icon="icon" flip="horizontal" :hFlip="false" />`,
 			data() {
 				return {
 					icon: iconData,

--- a/components/vue/tests/offline/20-attributes-test.ts
+++ b/components/vue/tests/offline/20-attributes-test.ts
@@ -59,6 +59,22 @@ describe('Passing attributes', () => {
 		expect(wrapper.html()).not.toContain('aria-hidden="true"');
 	});
 
+	test('ariaHidden shorthands', () => {
+		// camelCase, boolean value
+		const Wrapper = {
+			components: { Icon },
+			template: `<Icon :icon="icon" ariaHidden />`,
+			data() {
+				return {
+					icon: iconData,
+				};
+			},
+		};
+
+		const wrapper = mount(Wrapper, {});
+		expect(wrapper.html()).toContain('aria-hidden="true"');
+	});
+
 	test('style as string', () => {
 		const Wrapper = {
 			components: { Icon },

--- a/components/vue/tests/offline/20-inline-test.ts
+++ b/components/vue/tests/offline/20-inline-test.ts
@@ -8,6 +8,21 @@ const iconData = {
 };
 
 describe('Inline attribute', () => {
+	test('shorthands', () => {
+		const Wrapper = {
+			components: { Icon },
+			template: `<Icon :icon="icon" inline />`,
+			data() {
+				return {
+					icon: iconData,
+				};
+			},
+		};
+
+		const wrapper = mount(Wrapper, {});
+		expect(wrapper.html()).toContain('style="vertical-align: -0.125em;"');
+	});
+
 	test('string', () => {
 		const Wrapper = {
 			components: { Icon },


### PR DESCRIPTION
## Overview

Fixes the bug where boolean attribute shorthands (e.g. `<Icon inline />`) are not cast to `true` at runtime, causing the props to be silently ignored.

Fixes #3570

## Changes

### Declaring props in object syntax

Changed the `props` definition from an untyped array to object syntax and explicitly declared Boolean types for `inline`, `ssr`, `ariaHidden`, `hFlip`, and `vFlip`. This enables Vue's casting for boolean props, ensuring <Icon inline/> behaves identically to <Icon :inline="true"/>. This fix was applied to both the iconify.ts and offline.ts entry points.

### Deterministic `flip` merging

Declaring these props as `Boolean` alters how Vue internally resolves them, which consequently changes the key iteration order of the resulting `props` object.

Previously, [`render.ts`](https://github.com/iconify/iconify/blob/0b7494dfe5df3ad787894bc68089d89be0edfe7c/components/vue/src/render.ts#L120) implicitly relied on that iteration order to resolve conflicts between the `flip` shorthand (e.g., `flip="horizontal"`) and explicit `hFlip`/`vFlip` booleans. Whichever was processed last would "win." The typed-props change altered this order, flipping the precedence and breaking tests.

To preserve existing behavior, it is fixed by applying `flip` in a separate, explicit step after the main prop loop, so the result no longer depends on the key order. Because `flip` only ever asserts `true` (and never `false`), a `true` value from either the `flip` shorthand or the explicit boolean will now predictably override a conflicting `false`.

## Testing

- Added shorthand test cases for `inline` and `ariaHidden` (in both `iconify.ts` and `offline.ts` test suites).
- Added a test with `flip`/`hFlip` attributes in reversed order, confirming output no longer depends on attribute ordering.